### PR TITLE
Add Vite React setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# learning-platform
+# Learning Platform
+
+This repository now includes a frontend built with [Vite](https://vitejs.dev/) and React.
+
+## Getting Started
+
+1. Navigate to the `frontend` directory.
+2. Install dependencies with `npm install`.
+3. Start the development server with `npm run dev`.
+
+The application will be available at `http://localhost:5173` by default.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Learning Platform</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "learning-platform-frontend",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+function App() {
+  return (
+    <div>
+      <h1>Learning Platform</h1>
+      <p>Edit <code>src/App.jsx</code> and save to test HMR updates.</p>
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,5 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background-color: #f5f5f5;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- initialize React-based Vite project in `frontend`
- document how to start the dev server
- ignore build artifacts and node_modules

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc40f96048322b4903b01ed62176c